### PR TITLE
Fix on css file "how_we_work.css".

### DIFF
--- a/application/static/css/how_we_work.css
+++ b/application/static/css/how_we_work.css
@@ -19,6 +19,8 @@
     font-size: 1.2em;
     margin-bottom: 20px;
     color: orangered;
+    display: block;
+    margin-top: 20px;
 }
 
 .how-we-work-content h2 {


### PR DESCRIPTION
The ".how-we-work-content span" block has been fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout for the "How We Work" section with enhanced top margin and display properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->